### PR TITLE
Back-fill temporary array while copying to `ByteArray`

### DIFF
--- a/secure-random/src/wasmWasiMain/kotlin/org/kotlincrypto/SecureRandom.kt
+++ b/secure-random/src/wasmWasiMain/kotlin/org/kotlincrypto/SecureRandom.kt
@@ -54,7 +54,9 @@ public actual class SecureRandom public actual constructor() {
                 }
 
                 for (i in indices) {
-                    this[i] = (ptr + i).loadByte()
+                    val point = ptr.plus(i)
+                    this[i] = point.loadByte()
+                    point.storeByte(0)
                 }
             }
         }


### PR DESCRIPTION
Closes #15 